### PR TITLE
Point to alternative formats for docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ def get(url, qsargs=None, timeout=5.0):
 return request('get', url, qsargs=qsargs, timeout=timeout)
 ```
 
+While this is the default Sphinx-style for docstrings, [more legible alternatives exist](http://sphinx-doc.org/ext/napoleon.html).
+
 Don't document for the sake of documenting. The way to think about this is:
 
 ```python


### PR DESCRIPTION
The default Sphinx style for docstrings is hard to remember and not especially legible (unless rendered). Multiple friendlier alternatives exist, including the popular NumPy and Google formats, both of which can be rendered by the Sphinx Napoleon extension that is included with Sphinx.
