### PR TITLE
Make improvements to dedupe(), add new rule on in-place modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ def dedupe(items):
 
 The most important improvement is that `assert dedupe(items) == dedupe(items)` always holds true. For the "bad" version, since `items` is modified in-place, the `num_dupes` found on a second run of the function will always be `0`, since it **removes** the dupes from the passed-in list **as a side effect**.
 
-If we take our earlier advice on "prefer declarative to imperative", we can make this functions even clearer:
+If we take our earlier advice on "prefer declarative to imperative", we can make this function even clearer:
 
 ```python
 # best


### PR DESCRIPTION
This PR makes the `dedupe()` example clearer by making the return values of the various implementations more similar. This was raised in PR #13.

This also clarifies the distinction of declarative and imperative in an earlier rule, as raised in issue #10, by using a final "best" rewrite of this function as an example of that.

Finally, this PR adds a new rule. It clarifies the point this example was trying to make by illustrating a usage bug with impure functions related to in-place modification. The new rule is that if you **must** do in-place modifications, you should return `None` from your function, rather than returning the modified structure.
