### PR TITLE
An even better improvement to the dedupe() section

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ It's always better to have a `lib.time` module for time-related functions than t
 
 ### Declarative vs imperative
 
-You should prefer declarative to imperative programming. If you aren't familiar with the difference, Python's [functional programming guide][func] includes some good details and examples of how to use this style effectively.
+You should prefer declarative to imperative programming. This is code that says  **what** you want to do, rather than code that describes **how** to do it. Python's [functional programming guide][func] includes some good details and examples of how to use this style effectively.
 
 [func]: https://docs.python.org/3/howto/functional.html
 
@@ -387,7 +387,7 @@ David Beazley has [a YouTube tutorial on generators entitled "Generators: The Fi
 
 This is a concept that we can borrow from the functional programming community.  These kinds of functions and generators are alternatively described as "side-effect free", "referentially transparent", or as having "immutable inputs/outputs".
 
-As a simple example, you should **never** write code like this:
+As a simple example, you should avoid code like this:
 
 ```python
 # bad
@@ -401,7 +401,7 @@ def dedupe(items):
         else:
             seen.add(item)
     num_dupes = len(dupe_positions)
-    for idx in sorted(dupe_positions, reverse=True):
+    for idx in reversed(dupe_positions):
         items.pop(idx)
     return items, num_dupes
 ```

--- a/README.md
+++ b/README.md
@@ -349,29 +349,33 @@ It's always better to have a `lib.time` module for time-related functions than t
 
 ### Declarative vs imperative
 
-You should prefer declarative to imperative programming. If you don't know what the difference is, look it up.
+You should prefer declarative to imperative programming. If you aren't familiar with the difference, Python's [functional programming guide][func] includes some good details and examples of how to use this style effectively.
 
-Use lightweight data structures like `list`, `dict`, `tuple`, and `set` to your advantage. It's always better to lay out your data, and then write some code to transform it, than to build up your data imperatively by repeatedly calling functions/methods.
+[func]: https://docs.python.org/3/howto/functional.html
 
-The ultimate example of this is the common list comprehension refactoring:
+You should use lightweight data structures like `list`, `dict`, `tuple`, and `set` to your advantage. It's always better to lay out your data, and then write some code to transform it, than to build up data by repeatedly calling mutating functions/methods.
 
-```python
- filtered = []
- for x in items:
-     if x.endswith(".py"):
-         filtered.append(x)
- return filtered
-```
-
-should be rewritten as:
+An example of this is the common list comprehension refactoring:
 
 ```python
- return [x
-         for x in items
-         if x.endswith(".py")]
+# bad
+filtered = []
+for x in items:
+    if x.endswith(".py"):
+        filtered.append(x)
+return filtered
 ```
 
-But another good example is rewriting an if/else chain as a dictionary lookup or repetitive code as a tuple of operations followed by a for loop.
+This should be rewritten as:
+
+```python
+# good
+return [x
+        for x in items
+        if x.endswith(".py")]
+```
+
+But another good example is rewriting an `if`/`elif`/`else` chain as a `dict` lookup.
 
 ### Grok generators
 
@@ -388,18 +392,18 @@ As a simple example, you should **never** write code like this:
 ```python
 # bad
 def dedupe(items):
-    """Remove dupes in-place and returns number removed."""
+    """Remove dupes in-place, return items and # of dupes."""
     seen = set()
-    dupes = []
+    dupe_positions = []
     for i, item in enumerate(items):
         if item in seen:
-            dupes.append(i)
+            dupe_positions.append(i)
         else:
             seen.add(item)
-    num_removed = len(dupes)
-    for idx in sorted(dupes, reverse=True):
+    num_dupes = len(dupe_positions)
+    for idx in sorted(dupe_positions, reverse=True):
         items.pop(idx)
-    return num_removed
+    return items, num_dupes
 ```
 
 This same function can be written as follows:
@@ -407,11 +411,15 @@ This same function can be written as follows:
 ```python
 # good
 def dedupe(items):
-    """Return set of unique values in sequence."""
-    return set(items)
+    """Return deduped items and # of dupes."""
+    deduped = set(items)
+    num_dupes = len(items) - len(deduped)
+    return deduped, num_dupes
 ```
 
-This is a somewhat shocking example, because in addition to making this function "pure", we also made it much, much shorter. But it's not only shorter: it's better in a number of ways. The most important part is that for the good version, `assert dedupe(items) == dedupe(items)` always holds true. This makes it much easier to reason about, and much easier to test.
+This is a somewhat shocking example. In addition to making this function pure, we also made it much, much shorter. It's not only shorter: it's better. Its purity means `assert dedupe(items) == dedupe(items)` always holds true for the "good" version. In the "bad" version, `num_dupes` will **always** be `0` on the second call, which can lead to subtle bugs when using the function.
+
+This also illustrates imperative vs declarative style: the function now reads like a description of what we need, rather than a set of instructions to build up what we need.
 
 ### Prefer simple argument and return types
 


### PR DESCRIPTION
This takes the "best" rewrite of `dedupe()` from PR #19, but doesn't go overboard with a belabored discussion.

This PR also improves the declarative vs imperative section to link to Python's "Functional Programming HOWTO", which is an official part of the docs. So, this also addresses issues #10 and #21.

Would love to hear what these folks have to say about the changes:
- @TheNeuralBit (who asked for more details on declarative vs imperative)
- @j6k4m8 (who raised the issue of `dedupe()` being confusing in current version)
- @veprbl (who pointed out my first attempt at expanding this section was convoluted)

Hopefully this PR addresses all concerns.
